### PR TITLE
Grafana update

### DIFF
--- a/Grafana.dockerfile
+++ b/Grafana.dockerfile
@@ -1,21 +1,21 @@
 FROM ubuntu:14.04
 MAINTAINER Gregory Eremin <g@erem.in>
 LABEL app="grafana"
-LABEL version="3.1.0-beta1"
+LABEL version="4.1.1"
 LABEL github="https://github.com/grafana/grafana"
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get -y upgrade
-RUN apt-get install -y curl make git build-essential
+RUN apt-get install -y --force-yes curl make git build-essential
 
 # Installing Node.js
 RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
 RUN apt-get install -y nodejs && node -v && npm -v
 
 # Installing Go
-RUN cd /tmp && curl -O https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz
+RUN cd /tmp && curl -O https://storage.googleapis.com/golang/go1.7.5.linux-amd64.tar.gz
 WORKDIR /tmp
-RUN tar -xvf go1.6.linux-amd64.tar.gz
+RUN tar -xvf go1.7.5.linux-amd64.tar.gz
 RUN mv go /usr/local
 RUN mkdir /go
 # Setting up Go environment
@@ -27,15 +27,15 @@ RUN go version && go env
 
 RUN go get -d -v github.com/grafana/grafana || true
 WORKDIR /go/src/github.com/grafana/grafana
-RUN git checkout v3.1.0-beta1
+RUN git checkout v4.1.1
 
 RUN go run build.go setup
-RUN rm -rf Godeps/_workspace
-RUN godep restore
 RUN go run build.go build
 
-RUN npm install
+RUN npm install -g yarn
+RUN yarn install --pure-lockfile
 RUN npm run build
 
 EXPOSE 3000
 ENTRYPOINT ./bin/grafana-server
+

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
+ECS_LOGIN=$(shell aws ecr get-login --region us-east-1)
+
 build:
-	docker-compose build
+        docker-compose build
 
 run: build
-	docker-compose up
+        docker-compose up
 
 release: build
-	cat docker-compose.yml \
-	| grep "registry.vivino.com" \
-	| cut -d" " -f6 \
-	| xargs -n1 docker push
+        @$(ECS_LOGIN)
+        cat docker-compose.yml | grep "492946569230.dkr.ecr.us-east-1.amazonaws.com" |  cut -d" " -f6 | xargs -n1 docker push

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ daemon with other compatible components to improve
 [performance](https://github.com/lomik/go-carbon/tree/v0.7.2#performance) and
 [throughput](https://github.com/github/brubeck/tree/5d139a4#faq).
 
-Grafana 3 is also included.
+Grafana 4 is also included.
 
 ### Included images
 | Component | Version |   |
@@ -32,7 +32,7 @@ Grafana 3 is also included.
 | [go-carbon](https://github.com/lomik/go-carbon/tree/v0.7.2) | `v0.7.2` | Drop-in replacement for original `carbon` daemon, written in Go |
 | [Brubeck](https://github.com/github/brubeck/tree/5d139a4) | `5d139a4` | Easy replacement for `StatsD`, written in C |
 | [Graphite API](https://github.com/brutasse/graphite-api) | `latest` | A piece of original `Graphite Web` component with less features |
-| [Grafana](https://github.com/grafana/grafana/tree/v3.1.0-beta1) | `v3.1.0-beta1` | Beautiful dashboard for all of that |
+| [Grafana](https://github.com/grafana/grafana/tree/v4.1.1) | `v4.1.1` | Beautiful dashboard for all of that |
 
 ## Building
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   # Go Carbon (Carbon replacement)
   # Takes care of writing metrics to database and data retention
   carbon:
-    image: registry.vivino.com/carbon
+    image: 492946569230.dkr.ecr.us-east-1.amazonaws.com/carbon:v1
     build:
       dockerfile: Carbon.dockerfile
       context: .
@@ -17,7 +17,7 @@ services:
   # Brubeck (StatsD replacement)
   # Aggregates metrics before sending them to Carbon
   brubeck:
-    image: registry.vivino.com/brubeck
+    image: 492946569230.dkr.ecr.us-east-1.amazonaws.com/brubeck:v1
     build:
       dockerfile: Brubeck.dockerfile
       context: .
@@ -30,7 +30,7 @@ services:
   # Graphite API (yep, almost original Graphite Web)
   # Provides API for reading metrics
   graphite-api:
-    image: registry.vivino.com/graphite-api
+    image: 492946569230.dkr.ecr.us-east-1.amazonaws.com/graphite-api:v1
     build:
       context: https://github.com/brutasse/graphite-api.git
     environment:
@@ -46,7 +46,7 @@ services:
   # Grafana
   # Metrics dashboard
   grafana:
-    image: registry.vivino.com/grafana
+    image: 492946569230.dkr.ecr.us-east-1.amazonaws.com/grafana:4.4.1
     build:
       dockerfile: Grafana.dockerfile
       context: .


### PR DESCRIPTION
Updated Grafana image since the 3.x branch wouldn't build because of failing dependency. Switched to AWS hosted Docker registry.